### PR TITLE
Don't map ai/ii in select mode

### DIFF
--- a/lua/indent-tools/init.lua
+++ b/lua/indent-tools/init.lua
@@ -160,7 +160,7 @@ local function setup_textobj(opts)
 
   if opts.ii then
     local o = { silent = true, desc = "in indentation block" }
-    vim.keymap.set("v", opts.ii, function()
+    vim.keymap.set("x", opts.ii, function()
       in_indent(false)
     end, o)
     vim.keymap.set("o", opts.ii, function()
@@ -170,7 +170,7 @@ local function setup_textobj(opts)
 
   if opts.ai then
     local o = { silent = true, desc = "around indentation block" }
-    vim.keymap.set("v", opts.ai, function()
+    vim.keymap.set("x", opts.ai, function()
       in_indent(true)
     end, o)
     vim.keymap.set("o", opts.ai, function()


### PR DESCRIPTION
Using ii or ai in select mode results in the visual mode commands meant for setting the selection being input into the buffer as text. This patch changes the mapping commands to use mode "x" instead of "v" to avoid creating bindings in select mode.