### PR TITLE
Require "health" if not vim.health

### DIFF
--- a/lua/indent-tools/health.lua
+++ b/lua/indent-tools/health.lua
@@ -1,5 +1,5 @@
 local M = {}
-local health = vim.health
+local health = vim.health or require "health"
 
 M.check = function()
   health.report_start("Indent Tool Health Check")

--- a/lua/indent-tools/health.lua
+++ b/lua/indent-tools/health.lua
@@ -1,5 +1,5 @@
 local M = {}
-local health = vim.health or require "health"
+local health = vim.health or require("health")
 
 M.check = function()
   health.report_start("Indent Tool Health Check")


### PR DESCRIPTION
On neovim 0.7.2 I have the following healthcheck error: `E5108: Error executing lua ...cker/start/indent-tools.nvim/lua/indent-tools/health.lua:5: attempt to index upvalue 'health' (a nil value)`. Maybe `vim.health` is removed. So I added `require "health"`.